### PR TITLE
Fix configure generate an infinite amount of apply plugin strings

### DIFF
--- a/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
+++ b/packages/flutterfire_cli/lib/src/firebase/firebase_android_writes.dart
@@ -352,7 +352,7 @@ AndroidGradleContents _applyGoogleServicesPlugin(
     androidBuildGradleFileContents = updatedContent.buildGradleContent;
   }
 
-  if (!androidAppBuildGradleFileContents.contains(_googleServicesPluginClass)) {
+  if (!androidAppBuildGradleFileContents.contains(_googleServicesPluginName)) {
     final hasMatch =
         _androidAppBuildGradleRegex.hasMatch(androidAppBuildGradleFileContents);
     if (!hasMatch) {


### PR DESCRIPTION
## Description

Replace google services plugin class with google services plugin name in _applyGoogleServicesPlugin in firebase_android_writes

## Type of Change

- [ ] ✨ `feat` -- New feature (non-breaking change which adds functionality)
- [x] 🛠️ `fix` -- Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ `!` -- Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 `refactor` -- Code refactor
- [ ] ✅ `ci` -- Build configuration change
- [ ] 📝 `docs` -- Documentation
- [ ] 🗑️ `chore` -- Chore
